### PR TITLE
Isolate http-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lib/**/*.d.ts
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const config = {
 
 const audioTrackUrl = 'https://test-audio.netlify.com/Various%20Artists%20-%202009%20-%20netBloc%20Vol%2024_%20tiuqottigeloot%20%5BMP3-V2%5D/01%20-%20Diablo%20Swing%20Orchestra%20-%20Heroines.mp3';
 
-const streamingHttpTokenReader = new StreamingHttpTokenReader(audioTrackUrl, config);
+const streamingHttpTokenReader = StreamingHttpTokenReader.from(audioTrackUrl, config);
 streamingHttpTokenReader.init()
   .then(() => {
     return mm.parseFromTokenizer(streamingHttpTokenReader, streamingHttpTokenReader.contentType);

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -1,0 +1,79 @@
+import * as initDebug from 'debug';
+import * as _fetch from 'node-fetch';
+import { IContentRangeType, IHeadInfo, IHttpClient, IHttpResponse } from './types'; // Add 'fetch' API for node.js
+
+const debug = initDebug('streaming-http-token-reader:http-client');
+
+export function parseContentRange(contentRange: string): IContentRangeType {
+  debug(`_parseContentRang response: contentRange=${contentRange}`);
+
+  if (contentRange) {
+    const parsedContentRange = contentRange.match(
+      /bytes (\d+)-(\d+)\/(?:(\d+)|\*)/i
+    );
+    if (!parsedContentRange) {
+      throw new Error('FIXME: Unknown Content-Range syntax: ' + contentRange);
+    }
+
+    return {
+      firstBytePosition: parseInt(parsedContentRange[1], 10),
+      lastBytePosition: parseInt(parsedContentRange[2], 10),
+      instanceLength: parsedContentRange[3] ? parseInt(parsedContentRange[3], 10) : null
+    };
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Simple HTTP-client, which both works in node.js and browser
+ */
+export class HttpClient implements IHttpClient {
+
+  private static getContentLength(headers: _fetch.Headers): number {
+    const contentLength = headers.get('Content-Length');
+    return contentLength ? parseInt(contentLength, 10) : undefined;
+  }
+
+  private static parseContentRange(headers: _fetch.Headers): IContentRangeType {
+    const contentRange = headers.get('Content-Range');
+    return parseContentRange(contentRange);
+  }
+
+  private static makeResponse(resp): IHttpResponse {
+    return {
+      contentLength: HttpClient.getContentLength(resp.headers),
+      contentType: resp.headers.get('Content-Type'),
+      contentRange: HttpClient.parseContentRange(resp.headers),
+      arrayBuffer: () => resp.arrayBuffer()
+    };
+  }
+
+  constructor(private url: string) {
+  }
+
+  public getHeadInfo(): Promise<IHeadInfo> {
+    return _fetch(this.url, {method: 'HEAD'}).then(resp => HttpClient.makeResponse(resp));
+  }
+
+  public getResponse(method: string, range?: [number, number]): Promise<IHttpResponse> {
+    if (range) {
+      debug(`_makeXHRRequest ${method} ${range[0]}..${range[1]}`);
+    } else {
+      debug(`_makeXHRRequest ${method} (range not provided)`);
+    }
+
+    const headers = new _fetch.Headers();
+    headers.set('Range', 'bytes=' + range[0] + '-' + range[1]);
+
+    return _fetch(this.url, {method, headers}).then(response => {
+
+      if (response.ok) {
+        return HttpClient.makeResponse(response);
+      } else {
+        throw new Error(`Unexpected HTTP response status=${response.status}`);
+      }
+    });
+  }
+
+}

--- a/lib/streaming-http-token-reader.spec.ts
+++ b/lib/streaming-http-token-reader.spec.ts
@@ -25,7 +25,7 @@ const parsers: IParserTest[] = [
   {
     methodDescription: 'StreamingHttpTokenReader => parseTokenizer()',
     parseUrl: (audioTrackUrl, config, options) => {
-      const streamingHttpTokenReader = new StreamingHttpTokenReader(audioTrackUrl, config);
+      const streamingHttpTokenReader = StreamingHttpTokenReader.fromUrl(audioTrackUrl, config);
       return streamingHttpTokenReader.init().then(() => {
         return mm.parseFromTokenizer(streamingHttpTokenReader, streamingHttpTokenReader.contentType, options);
       });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,20 @@
+export interface IContentRangeType {
+  firstBytePosition?: number;
+  lastBytePosition?: number;
+  instanceLength?: number;
+}
+
+export interface IHeadInfo {
+  contentLength?: number;
+  contentType?: string;
+  contentRange?: IContentRangeType;
+}
+
+export interface IHttpResponse extends IHeadInfo {
+  arrayBuffer: () => Promise<Buffer>;
+}
+
+export interface IHttpClient {
+  getHeadInfo(): Promise<IHeadInfo>
+  getResponse(method: string, range?: [number, number]): Promise<IHttpResponse>;
+}

--- a/node/test/test.ts
+++ b/node/test/test.ts
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 import {tiuqottigeloot_vol24_Tracks, providers} from './test-data';
-import * as mmCore from 'music-metadata/lib/core';
+import * as mm from 'music-metadata';
 
 import {StreamingHttpTokenReader} from '../../lib/streaming-http-token-reader'
 
@@ -16,9 +16,9 @@ describe('streaming-http-token-reader with Node.js', function() {
     const track = tiuqottigeloot_vol24_Tracks[0];
     const audioTrackUrl = providers.netlify.getUrl(track.url);
 
-    const streamingHttpTokenReader = new StreamingHttpTokenReader(audioTrackUrl, config);
+    const streamingHttpTokenReader = StreamingHttpTokenReader.fromUrl(audioTrackUrl, config);
     await streamingHttpTokenReader.init();
-    const metadata = await mmCore.parseFromTokenizer(streamingHttpTokenReader, streamingHttpTokenReader.contentType, {});
+    const metadata = await mm.parseFromTokenizer(streamingHttpTokenReader, streamingHttpTokenReader.contentType, {});
     assert.equal(metadata.format.container, 'MPEG', 'metadata.format.container');
   });
 


### PR DESCRIPTION
Allow third party HTTP-client to deal with HTTP-requests, like [aws-sdk/clients/s3](https://github.com/aws/aws-sdk-js).

```js
//
// Example chunked streaming audio track from S3 buckets into music-metadata parser
//

const S3 = require('aws-sdk/clients/s3');
const mm = require('music-metadata');
const {StreamingHttpTokenReader} = require('streaming-http-token-reader');
const {parseContentRange} = require('streaming-http-token-reader/lib/http-client');

const s3 = new S3();
const wav = 'WAV/02 - Poxfil - Solid Ground.wav';
const config = {
  avoidHeadRequests: true
};

/**
 * Use S3-client to execute actual HTTP-requests
 */
class S3Request {

  constructor(bucket, key) {
    this.bucket = bucket;
    this.key = key;
  }

  async getResponse(method, range) {

    return s3.getObject({
      Bucket: this.bucket,
      Key: this.key,
      Range: `bytes=${range[0]}-${range[1]}`
    }).promise().then(data => {
      return {
        contentLength: data.ContentLength,
        contentType: data.ContentType,
        contentRange: parseContentRange(data.ContentRange),
        arrayBuffer: async() => {
          return data.Body
        }
      }
    });
  }
}

(async () => {

  const s3Request = new S3Request('music-metadata', wav);

  console.log('Parsing...');
  try {
    const streamingHttpTokenReader = new StreamingHttpTokenReader(s3Request, config);
    const t0 = new Date().getTime();
    await streamingHttpTokenReader.init();
    const metadata = await mm.parseFromTokenizer(streamingHttpTokenReader, streamingHttpTokenReader.contentType, {});
    const t1 = new Date().getTime();
    console.log(`Read metadata in ${t1 - t0} milliseconds.`);
    console.log('metadata:', metadata);
  } catch (e) {
    console.error(`Oops: ${e.message}`);
  }
})();

```